### PR TITLE
Make KMS Proxy not use stale tokens and add time synchronization service

### DIFF
--- a/build/local_image_deps.sh
+++ b/build/local_image_deps.sh
@@ -8,7 +8,7 @@ case $local_arch in
 		rust_target="x86_64-unknown-linux-musl"
 		;;
 	aarch64)
-		rust_target="aarch64-unknown-linux-musl"
+		rust_target="aarch64-unknown-linux-gnu"
 		;;
 	*)
 		echo "Unsupported architecture: $local_arch"

--- a/enclaver/Cargo.lock
+++ b/enclaver/Cargo.lock
@@ -748,8 +748,10 @@ checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -993,6 +995,7 @@ dependencies = [
  "bollard",
  "bytes",
  "cbc",
+ "chrono",
  "circbuf",
  "clap",
  "console-subscriber",
@@ -1007,6 +1010,7 @@ dependencies = [
  "ipnetwork",
  "json",
  "lazy_static",
+ "libc",
  "log",
  "nix 0.24.3",
  "pkcs8",
@@ -1015,6 +1019,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rsa",
+ "rsntp",
  "rtnetlink",
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
@@ -1820,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
@@ -2520,6 +2525,16 @@ dependencies = [
  "smallvec",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rsntp"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cce5f45764fc4f0da82badc165fec123f137f2b2ba7112778a83575bc6af3e1"
+dependencies = [
+ "chrono",
+ "tokio",
 ]
 
 [[package]]

--- a/enclaver/Cargo.toml
+++ b/enclaver/Cargo.toml
@@ -72,6 +72,9 @@ aes = "0.8"
 sha2 = "0.10"
 ignore-result = "0.2.0"
 console-subscriber = { version = "0.1.10", optional = true }
+rsntp = "4.0.0"
+libc = "0.2.172"
+chrono = { version = "0.4.31", features = [ "serde" ] }
 
 [dev-dependencies]
 assert2 = "0.3"

--- a/enclaver/src/bin/odyn/time.rs
+++ b/enclaver/src/bin/odyn/time.rs
@@ -1,0 +1,43 @@
+use crate::config::Configuration;
+use anyhow::Result;
+use enclaver::constants::TIME_VSOCK_PORT;
+use enclaver::proxy::time::EnclaveTime;
+use libc::{clock_settime, timespec, CLOCK_REALTIME};
+use log::info;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+
+pub struct TimeService {
+    task: JoinHandle<()>,
+}
+
+impl TimeService {
+    pub async fn start(_config: &Configuration) -> Result<Self> {
+        info!("Starting time");
+        let task = tokio::task::spawn(async move {
+            loop {
+                if let Ok(date) = EnclaveTime::request(TIME_VSOCK_PORT).await {
+                    // https://github.com/uutils/coreutils/blob/60fbf1db84421405c6e7c84db5489dd2b293c622/src/uu/date/src/date.rs#L433
+                    let timespec = timespec {
+                        tv_sec: date.timestamp() as _,
+                        tv_nsec: date.timestamp_subsec_nanos() as _,
+                    };
+                    info!("Setting date inside enclave to {:?}", date);
+                    let result = unsafe { clock_settime(CLOCK_REALTIME, &timespec) };
+                    if result != 0 {
+                        info!("failed to set date: {:?}", std::io::Error::last_os_error());
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(5 * 60)).await;
+            }
+        });
+
+        Ok(Self { task })
+    }
+
+    pub async fn stop(self) {
+        let task = self.task;
+        task.abort();
+        _ = task.await;
+    }
+}

--- a/enclaver/src/constants.rs
+++ b/enclaver/src/constants.rs
@@ -13,6 +13,7 @@ pub const RELEASE_BUNDLE_DIR: &str = "/enclave";
 pub const STATUS_PORT: u32 = 17000;
 pub const APP_LOG_PORT: u32 = 17001;
 pub const HTTP_EGRESS_VSOCK_PORT: u32 = 17002;
+pub const TIME_VSOCK_PORT: u32 = 17003;
 
 // Default TCP Port that the egress proxy listens on inside the enclave, if not
 // specified in the manifest.

--- a/enclaver/src/proxy/egress_http.rs
+++ b/enclaver/src/proxy/egress_http.rs
@@ -20,7 +20,7 @@ use tokio_vsock::VsockStream;
 use crate::policy::EgressPolicy;
 
 #[async_trait]
-trait JsonTransport: Sized + Sync {
+pub trait JsonTransport: Sized + Sync {
     async fn send<W: AsyncWrite + Unpin + Send>(&self, w: &mut W) -> anyhow::Result<()>;
     async fn recv<R: AsyncRead + Unpin + Send>(r: &mut R) -> anyhow::Result<Self>;
 }

--- a/enclaver/src/proxy/mod.rs
+++ b/enclaver/src/proxy/mod.rs
@@ -1,6 +1,7 @@
 pub mod aws_util;
 pub mod egress_http;
 pub mod ingress;
+pub mod time;
 
 #[cfg(feature = "odyn")]
 pub mod kms;

--- a/enclaver/src/proxy/time.rs
+++ b/enclaver/src/proxy/time.rs
@@ -1,0 +1,73 @@
+use crate::proxy::egress_http::JsonTransport;
+use anyhow::anyhow;
+use chrono::{DateTime, Utc};
+use futures::{Stream, StreamExt};
+use log::{debug, error, info};
+use serde::{Deserialize, Serialize};
+use tokio_vsock::VsockStream;
+
+#[derive(Serialize, Deserialize)]
+struct TimeRequest();
+
+#[derive(Serialize, Deserialize)]
+enum TimeResponse {
+    Ok(DateTime<Utc>),
+    Err(String),
+}
+
+pub struct EnclaveTime {}
+impl EnclaveTime {
+    pub async fn request(egress_port: u32) -> anyhow::Result<DateTime<Utc>> {
+        let mut vsock = VsockStream::connect(crate::vsock::VMADDR_CID_HOST, egress_port).await?;
+        debug!(
+            "Connected to vsock {}:{}, sending time request",
+            crate::vsock::VMADDR_CID_HOST,
+            egress_port
+        );
+
+        TimeRequest().send(&mut vsock).await?;
+        debug!("Sent time request");
+
+        match TimeResponse::recv(&mut vsock).await? {
+            TimeResponse::Ok(dt) => Ok(dt),
+            TimeResponse::Err(e) => Err(anyhow!("Failure: {}", e)),
+        }
+    }
+}
+
+pub struct HostTime {
+    incoming: Box<dyn Stream<Item = VsockStream> + Unpin + Send>,
+}
+impl HostTime {
+    pub fn bind(egress_port: u32) -> anyhow::Result<Self> {
+        Ok(Self {
+            incoming: Box::new(crate::vsock::serve(egress_port)?),
+        })
+    }
+    pub async fn serve(self) {
+        let mut incoming = Box::into_pin(self.incoming);
+
+        while let Some(stream) = incoming.next().await {
+            tokio::task::spawn(async move {
+                if let Err(err) = HostTime::service_conn(stream).await {
+                    error!("{err}");
+                }
+            });
+        }
+    }
+    async fn service_conn(mut vsock: VsockStream) -> anyhow::Result<()> {
+        let _ = TimeRequest::recv(&mut vsock).await?;
+        use rsntp::AsyncSntpClient;
+        let client = AsyncSntpClient::new();
+        info!("Querying time in host");
+        let resp = match client.synchronize("time.aws.com").await {
+            Ok(result) => match result.datetime().into_chrono_datetime() {
+                Ok(date) => TimeResponse::Ok(date),
+                Err(e) => TimeResponse::Err(format!("Failed to convert response: {:?}", e)),
+            },
+            Err(e) => TimeResponse::Err(format!("Failed to get response: {:?}", e)),
+        };
+        resp.send(&mut vsock).await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
I have not revised these commits to be generally applicable. I think they are, but I have only really tested them on our deployment.