### PR TITLE
Output image sources info

### DIFF
--- a/enclaver/src/bin/enclaver/main.rs
+++ b/enclaver/src/bin/enclaver/main.rs
@@ -4,7 +4,7 @@ use enclaver::{
     build::ResolvedSources,
     nitro_cli::EIFMeasurements,
     build::EnclaveArtifactBuilder, constants::MANIFEST_FILE_NAME, manifest::load_manifest,
-    run_container::RunWrapper,
+    run_container::Sleeve,
     images::ImageRef,
 };
 use log::{debug, error};
@@ -142,7 +142,7 @@ async fn run(args: Cli) -> Result<()> {
                 )),
             }?;
 
-            let mut runner = RunWrapper::new()?;
+            let mut runner = Sleeve::new()?;
 
             let shutdown_signal = enclaver::utils::register_shutdown_signal_handler().await?;
 

--- a/enclaver/src/build.rs
+++ b/enclaver/src/build.rs
@@ -25,7 +25,7 @@ const RELEASE_OVERLAY_CHOWN: &str = "0:0";
 const NITRO_CLI_IMAGE: &str = "public.ecr.aws/s2t1d4c6/enclaver-io/nitro-cli:latest";
 const ODYN_IMAGE: &str = "public.ecr.aws/s2t1d4c6/enclaver-io/odyn:latest";
 const ODYN_IMAGE_BINARY_PATH: &str = "/usr/local/bin/odyn";
-const RELEASE_BASE_IMAGE: &str = "public.ecr.aws/s2t1d4c6/enclaver-io/enclaver-wrapper-base:latest";
+const SLEEVE_IMAGE: &str = "public.ecr.aws/s2t1d4c6/enclaver-io/enclaver-wrapper-base:latest";
 
 pub struct EnclaveArtifactBuilder {
     docker: Arc<Docker>,
@@ -217,7 +217,7 @@ impl EnclaveArtifactBuilder {
         let packaged_img = self
             .image_manager
             .append_layer(
-                &sources.release_base,
+                &sources.sleeve,
                 LayerBuilder::new()
                     .append_file(FileBuilder {
                         path: PathBuf::from(RELEASE_BUNDLE_DIR).join(MANIFEST_FILE_NAME),
@@ -361,21 +361,21 @@ impl EnclaveArtifactBuilder {
         info!("using app image: {app}");
 
         let odyn = self
-            .resolve_internal_source_image(manifest.sources.supervisor.as_deref(), ODYN_IMAGE)
+            .resolve_internal_source_image(manifest.sources.odyn.as_deref(), ODYN_IMAGE)
             .await?;
-        if manifest.sources.supervisor.is_none() {
+        if manifest.sources.odyn.is_none() {
             debug!("no supervisor image specified in manifest; using default: {odyn}");
         } else {
             info!("using supervisor image: {odyn}");
         }
 
         let release_base = self
-            .resolve_internal_source_image(manifest.sources.wrapper.as_deref(), RELEASE_BASE_IMAGE)
+            .resolve_internal_source_image(manifest.sources.sleeve.as_deref(), SLEEVE_IMAGE)
             .await?;
-        if manifest.sources.wrapper.is_none() {
-            debug!("no wrapper base image specified in manifest; using default: {release_base}");
+        if manifest.sources.sleeve.is_none() {
+            debug!("no sleeve base image specified in manifest; using default: {release_base}");
         } else {
-            info!("using wrapper base image: {release_base}");
+            info!("using sleeve base image: {release_base}");
         }
 
         let nitro_cli = self
@@ -387,7 +387,7 @@ impl EnclaveArtifactBuilder {
             app,
             odyn,
             nitro_cli,
-            release_base,
+            sleeve: release_base,
         };
 
         Ok(sources)
@@ -412,6 +412,6 @@ pub struct ResolvedSources {
     #[serde(rename = "NitroCLI")]
     nitro_cli: ImageRef,
 
-    #[serde(rename = "ReleaseBase")]
-    release_base: ImageRef,
+    #[serde(rename = "Sleeve")]
+    sleeve: ImageRef,
 }

--- a/enclaver/src/lib.rs
+++ b/enclaver/src/lib.rs
@@ -4,11 +4,12 @@ extern crate core;
 
 pub mod build;
 
-mod images;
+pub mod images;
 
 pub mod constants;
 
 pub mod nitro_cli;
+pub mod nitro_cli_container;
 
 pub mod manifest;
 

--- a/enclaver/src/manifest.rs
+++ b/enclaver/src/manifest.rs
@@ -29,8 +29,8 @@ pub struct Manifest {
 #[serde(deny_unknown_fields)]
 pub struct Sources {
     pub app: String,
-    pub supervisor: Option<String>,
-    pub wrapper: Option<String>,
+    pub odyn: Option<String>,
+    pub sleeve: Option<String>,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/enclaver/src/nitro_cli.rs
+++ b/enclaver/src/nitro_cli.rs
@@ -109,22 +109,22 @@ impl NitroCLI {
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EIFInfo {
     #[serde(rename = "Measurements")]
-    measurements: EIFMeasurements,
+    pub measurements: EIFMeasurements,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EIFMeasurements {
     #[serde(rename = "PCR0")]
-    pcr0: String,
+    pub pcr0: String,
 
     #[serde(rename = "PCR1")]
-    pcr1: String,
+    pub pcr1: String,
 
     #[serde(rename = "PCR2")]
-    pcr2: String,
+    pub pcr2: String,
 
     #[serde(rename = "PCR8", skip_serializing_if = "Option::is_none")]
-    pcr8: Option<String>,
+    pub pcr8: Option<String>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]

--- a/enclaver/src/nitro_cli_container.rs
+++ b/enclaver/src/nitro_cli_container.rs
@@ -1,0 +1,159 @@
+use std::sync::Arc;
+use std::path::PathBuf;
+use anyhow::{anyhow, Result};
+use bollard::{Docker, models::{Mount, MountTypeEnum}};
+use bollard::container::LogOutput;
+use bollard::query_parameters::{LogsOptions, CreateContainerOptions, StartContainerOptions, WaitContainerOptions, RemoveContainerOptions};
+use bollard::models::{ContainerCreateBody, HostConfig};
+use futures::{future, Stream, TryStreamExt};
+use crate::images::ImageRef;
+use log::debug;
+
+pub struct SigningInfo {
+    pub key: PathBuf,
+    pub certificate: PathBuf,
+}
+
+pub struct NitroCLIContainer {
+    docker: Arc<Docker>,
+    image: ImageRef,
+}
+
+impl NitroCLIContainer {
+    pub fn new(docker: Arc<Docker>, image: ImageRef) -> Self {
+        Self { docker, image }
+    }
+
+    pub async fn build_enclave(&self, eif_name: &str, img_tag: &str, build_dir_path: &str, sign: Option<SigningInfo>) -> Result<String> {
+        debug!("using nitro-cli image: {}", self.image.to_str());
+
+        let mut cmd = vec![
+            "build-enclave",
+            "--docker-uri",
+            img_tag,
+            "--output-file",
+            eif_name,
+        ];
+
+        let mut mounts = vec![
+            Mount {
+                typ: Some(MountTypeEnum::BIND),
+                source: Some(String::from("/var/run/docker.sock")),
+                target: Some(String::from("/var/run/docker.sock")),
+                ..Default::default()
+            },
+            Mount {
+                typ: Some(MountTypeEnum::BIND),
+                source: Some(build_dir_path.into()),
+                target: Some(String::from("/build")),
+                ..Default::default()
+            },
+        ];
+
+        if let Some(sign) = sign {
+            cmd.push("--signing-certificate");
+            cmd.push("/var/run/certificate");
+            cmd.push("--private-key");
+            cmd.push("/var/run/key");
+
+            mounts.push(Mount {
+                typ: Some(MountTypeEnum::BIND),
+                source: Some(sign.key.to_string_lossy().to_string()),
+                target: Some(String::from("/var/run/key")),
+                ..Default::default()
+            });
+
+            mounts.push(Mount {
+                typ: Some(MountTypeEnum::BIND),
+                source: Some(sign.certificate.to_string_lossy().to_string()),
+                target: Some(String::from("/var/run/certificate")),
+                ..Default::default()
+            });
+        }
+
+        let container_id = self
+            .docker
+            .create_container(
+                None::<CreateContainerOptions>,
+                ContainerCreateBody {
+                    image: Some(self.image.to_string()),
+                    cmd: Some(cmd.iter().map(|s| s.to_string()).collect()),
+                    attach_stderr: Some(true),
+                    attach_stdout: Some(true),
+                    host_config: Some(HostConfig {
+                        mounts: Some(mounts),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await?
+            .id;
+
+        self.docker
+            .start_container(&container_id, None::<StartContainerOptions>)
+            .await?;
+
+        Ok(container_id)
+    }
+
+    pub fn stderr(&self, container_id: &str, follow: bool) -> impl Stream<Item = String> {
+        use futures::StreamExt;
+
+        // Convert docker output to log lines, to give the user some feedback as to what is going on.
+        let log_stream = self.docker.logs(
+            container_id,
+            Some(LogsOptions {
+                follow,
+                stderr: true,
+                ..Default::default()
+            }),
+        );
+
+        log_stream.filter_map(|out| match out {
+            Ok(LogOutput::StdErr { message }) => {
+                future::ready(Some(String::from_utf8_lossy(&message).to_string()))
+            }
+            _ => future::ready(None),
+        })
+    }
+
+    pub fn stdout(&self, container_id: &str, follow: bool) -> impl Stream<Item = String> {
+        use futures::StreamExt;
+
+        // Convert docker output to log lines, to give the user some feedback as to what is going on.
+        let log_stream = self.docker.logs(
+            container_id,
+            Some(LogsOptions {
+                follow,
+                stdout: true,
+                ..Default::default()
+            }),
+        );
+
+        log_stream.filter_map(|out| match out {
+            Ok(LogOutput::StdOut { message }) => {
+                future::ready(Some(String::from_utf8_lossy(&message).to_string()))
+            }
+            _ => future::ready(None),
+        })
+    }
+
+    pub async fn wait_container(&self, container_id: &str) -> Result<i64> {
+        let status_code = self
+            .docker
+            .wait_container(container_id, None::<WaitContainerOptions>)
+            .try_collect::<Vec<_>>()
+            .await?
+            .first()
+            .ok_or_else(|| anyhow!("missing wait response from daemon",))?
+            .status_code;
+
+        Ok(status_code)
+    }
+
+    pub async fn remove_container(&self, container_id: &str) -> Result<()> {
+        self.docker.remove_container(container_id, None::<RemoveContainerOptions>).await?;
+        Ok(())
+    }
+}

--- a/enclaver/src/run_container.rs
+++ b/enclaver/src/run_container.rs
@@ -11,13 +11,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
 
-pub struct RunWrapper {
+pub struct Sleeve {
     docker: Arc<Docker>,
     container_id: Option<String>,
     stream_task: Option<tokio::task::JoinHandle<()>>,
 }
 
-impl RunWrapper {
+impl Sleeve {
     pub fn new() -> Result<Self> {
         let docker_client = Arc::new(
             Docker::connect_with_local_defaults()

--- a/example/enclaver.yaml
+++ b/example/enclaver.yaml
@@ -3,8 +3,8 @@ name: "example"
 target: "enclave:latest"
 sources:
   app: "app:latest"
-  #supervisor: "odyn-dev:latest"
-  #wrapper: "enclaver-wrapper-base:latest"
+  #odyn: "odyn-dev:latest"
+  #sleeve: "enclaver-wrapper-base:latest"
 defaults:
   memory_mb: 1500
 ingress:

--- a/example/enclaver.yaml
+++ b/example/enclaver.yaml
@@ -3,8 +3,8 @@ name: "example"
 target: "enclave:latest"
 sources:
   app: "app:latest"
-  supervisor: "odyn-dev:latest"
-  wrapper: "enclaver-wrapper-base:latest"
+  #supervisor: "odyn-dev:latest"
+  #wrapper: "enclaver-wrapper-base:latest"
 defaults:
   memory_mb: 1500
 ingress:


### PR DESCRIPTION
A build pulls a number of helper docker images
(besides the app itself). In addition to printing
the EIF PCR measurements, also print the information
about the helper images that were used.

This information can be used for SLSA verification.